### PR TITLE
fix: fix hover on profile menu

### DIFF
--- a/src/components/Popover.tsx
+++ b/src/components/Popover.tsx
@@ -80,7 +80,7 @@ export const Popover: React.FC<PopoverProps> = ({
             key={option.id}
             onClick={option.onClick}
             disabled={option.disabled}
-            className={option.className + " " + "hover:bg-red-500"}
+            className={option.className}
           >
             {typeof option.item === "string" ? (
               <span>{option.item}</span>


### PR DESCRIPTION
This pull request includes a small change to the `Popover` component in `src/components/Popover.tsx`. The change removes the hardcoded `"hover:bg-red-500"` class from the `className` property, ensuring that only the `option.className` value is applied.