### PR TITLE
Fix: Use the correct date (today) for setting the last review date

### DIFF
--- a/src/app/api/card/[cardId]/review/route.ts
+++ b/src/app/api/card/[cardId]/review/route.ts
@@ -56,13 +56,7 @@ export const POST = async (req: Request, params: { params: Params }) => {
     });
 
     // re-calculate next review date
-    // For now we are hardcoding two days from now
-    const nextReviewDate = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000);
-    const updatedCard = card.processCardReview(
-      cardExists,
-      Number(body.rating),
-      nextReviewDate.getTime()
-    );
+    const updatedCard = card.processCardReview(cardExists, Number(body.rating));
 
     await prisma.card.update({
       where: {

--- a/src/features/card/logic/processCardReview.ts
+++ b/src/features/card/logic/processCardReview.ts
@@ -3,11 +3,7 @@ import { calculateNewEaseFactor } from "./calculateEaseFactor";
 import { calculateNextDueDate } from "./calculateNextDueDate";
 import { calculateNextInterval } from "./calculateNextInterval";
 
-export const processCardReview = (
-  card: Card,
-  rating: number,
-  currentTime: number
-) => {
+export const processCardReview = (card: Card, rating: number) => {
   const isSuccessful = rating >= 3;
   const newRepetitions = isSuccessful ? card.repetitions + 1 : 0;
   const newEaseFactor = calculateNewEaseFactor(card.easeFactor, rating);
@@ -28,6 +24,6 @@ export const processCardReview = (
     interval: newInterval,
     newDueDate: newDueDate,
     repetitions: newRepetitions,
-    lastReviewedAt: currentTime,
+    lastReviewedAt: new Date(),
   };
 };


### PR DESCRIPTION
This pull request refactors the `processCardReview` logic to simplify how review dates are calculated and stored. The changes remove the need to pass the current time explicitly and instead use the current date directly within the function.

Refactoring of review logic:

* `src/app/api/card/[cardId]/review/route.ts`: Removed hardcoded calculation of the next review date and updated the `processCardReview` function call to exclude the `nextReviewDate` parameter. ([src/app/api/card/[cardId]/review/route.tsL59-R59](diffhunk://#diff-9569d6abdf6ff7921df862b609329ad90d2f4723aaef5e90a6994592b9384cecL59-R59))
* [`src/features/card/logic/processCardReview.ts`](diffhunk://#diff-cc74b5e6d9644b6f2d473773a3f4ff9a2243e2dc8013d3ab53fa2f3d7c599f4cL6-R6): Simplified the `processCardReview` function by removing the `currentTime` parameter and directly using `new Date()` for the `lastReviewedAt` field. [[1]](diffhunk://#diff-cc74b5e6d9644b6f2d473773a3f4ff9a2243e2dc8013d3ab53fa2f3d7c599f4cL6-R6) [[2]](diffhunk://#diff-cc74b5e6d9644b6f2d473773a3f4ff9a2243e2dc8013d3ab53fa2f3d7c599f4cL31-R27)