### PR TITLE
Feat: implement a new button bar such that buttons are always in the same place

### DIFF
--- a/src/app/sentence/page.tsx
+++ b/src/app/sentence/page.tsx
@@ -12,6 +12,7 @@ import { useUser } from "@/providers/LoggedUserProvider";
 import { useTranslations } from "next-intl";
 
 export default function Page() {
+  const t = useTranslations("sentence");
   const [showDefinition, setShowDefinition] = useState(false);
   const [selectedSentenceIdx, setSelectedSentenceIdx] = useState(0);
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -134,8 +135,6 @@ export default function Page() {
           <AnimatePresence mode={"wait"}>
             {showDefinition && (
               <Definition
-                onWrong={handleWrong}
-                onRight={handleRight}
                 sentenceDefinition={selectedSentence?.translation ?? ""}
                 words={selectedSentence?.definitions ?? []}
               />
@@ -143,9 +142,51 @@ export default function Page() {
           </AnimatePresence>
         </div>
       )}
+      <div
+        className={
+          "absolute bottom-0 left-0 right-0 mx-auto rounded-sm backdrop-blur-xl bg-white/10 w-full  p-xSmall md:max-w-[600px] xl:max-w-[850px]"
+        }
+      >
+        <SentenceButtons
+          skipLabel={showDefinition ? t("wrong") : t("skip")}
+          confirmLabel={showDefinition ? t("right") : t("show-answer")}
+          onConfirm={showDefinition ? handleRight : handleShowAnswer}
+          onSkip={showDefinition ? handleWrong : handleSkip}
+        />
+      </div>
     </motion.div>
   );
 }
+
+const SentenceButtons = ({
+  onSkip,
+  onConfirm,
+  skipLabel,
+  confirmLabel,
+}: {
+  confirmLabel: string;
+  skipLabel: string;
+  onSkip: () => void;
+  onConfirm: () => void;
+}) => {
+  return (
+    <motion.div
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      initial={{ opacity: 0 }}
+      transition={{ duration: 0.3, delay: 0.5 }}
+      className={"flex w-full justify-between px-large"}
+      style={{ width: "100%" }}
+    >
+      <Button variant="secondary" onClick={onSkip}>
+        {skipLabel}
+      </Button>
+      <Button variant="primary" onClick={onConfirm}>
+        {confirmLabel}
+      </Button>
+    </motion.div>
+  );
+};
 
 type SentenceProps = {
   content: string;
@@ -154,14 +195,8 @@ type SentenceProps = {
   onShowAnswer: () => void;
 };
 
-const Sentence: React.FC<SentenceProps> = ({
-  content,
-  onSkip,
-  onShowAnswer,
-  answerDisplayed,
-}) => {
+const Sentence: React.FC<SentenceProps> = ({ content, answerDisplayed }) => {
   const contentValue = useAnimatedText(content);
-  const t = useTranslations("sentence");
 
   const textVariants = {
     large: {
@@ -194,23 +229,6 @@ const Sentence: React.FC<SentenceProps> = ({
       >
         {contentValue}
       </motion.p>
-      {!answerDisplayed && (
-        <motion.div
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          initial={{ opacity: 0 }}
-          transition={{ duration: 0.3, delay: 0.5 }}
-          className={"flex w-full justify-between"}
-          style={{ width: "100%" }}
-        >
-          <Button variant="secondary" onClick={onSkip}>
-            {t("skip")}
-          </Button>
-          <Button variant="primary" onClick={onShowAnswer}>
-            {t("show-answer")}
-          </Button>
-        </motion.div>
-      )}
     </motion.div>
   );
 };
@@ -218,8 +236,6 @@ const Sentence: React.FC<SentenceProps> = ({
 type DefinitionProps = {
   sentenceDefinition: string;
   words: Array<WordDefinition>;
-  onWrong: () => void;
-  onRight: () => void;
 };
 
 type WordDefinition = {
@@ -230,11 +246,7 @@ type WordDefinition = {
 const Definition: React.FC<DefinitionProps> = ({
   sentenceDefinition,
   words,
-  onWrong,
-  onRight,
 }) => {
-  const t = useTranslations("sentence");
-
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -267,14 +279,6 @@ const Definition: React.FC<DefinitionProps> = ({
           })}
         </div>
       </Card>
-      <div className={"flex w-full justify-between"}>
-        <Button variant="secondary" onClick={onWrong}>
-          {t("wrong")}
-        </Button>
-        <Button variant="primary" onClick={onRight}>
-          {t("right")}
-        </Button>
-      </div>
     </motion.div>
   );
 };


### PR DESCRIPTION
This pull request refactors the `Page` component in `src/app/sentence/page.tsx` to improve code organization and simplify the handling of sentence-related actions. The changes include extracting sentence action buttons into a dedicated `SentenceButtons` component, removing redundant props, and streamlining the logic for displaying buttons based on the current state.

### Refactoring for Improved Code Organization:
* Extracted sentence action buttons into a new `SentenceButtons` component to encapsulate button-related logic and reduce repetition. This component dynamically updates button labels and handlers based on the `showDefinition` state. (`[[1]](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39L137-L164)`, `[[2]](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39L197-L222)`)

### Simplification of Component Props:
* Removed unused props (`onWrong`, `onRight`, `onSkip`, `onShowAnswer`) from `DefinitionProps` and `SentenceProps` to simplify the interface of `Definition` and `Sentence` components. (`[[1]](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39L233-L237)`, `[[2]](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39L270-L277)`)
* Removed redundant `useTranslations` hook usage from the `Sentence` and `Definition` components, centralizing translation handling in the `SentenceButtons` component. (`[[1]](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39R15)`, `[[2]](diffhunk://#diff-d08705e1199a623d9d3f901439c14155e00f7c0caa48c622f8be97e8dfaefd39L233-L237)`)