### PR TITLE
Feat: implement data structure on db for elo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Core Commands
+- `pnpm dev` - Start development server with Turbopack
+- `pnpm build` - Build production version
+- `pnpm lint` - Run ESLint
+- `pnpm test` - Run tests with Vitest
+- `pnpm postinstall` - Generate Prisma client (runs automatically after install)
+
+### Database Commands
+- `npx prisma generate` - Generate Prisma client
+- `npx prisma db push` - Push schema changes to database
+- `npx prisma migrate deploy` - Deploy migrations in production
+- `npx prisma studio` - Open Prisma Studio for database GUI
+
+### Testing
+- `pnpm test` - Run all tests with Vitest
+- Tests are located in `src/features/card/logic/__tests__/`
+- Testing framework uses Vitest with jsdom environment
+
+## Project Architecture
+
+### Tech Stack
+- **Framework**: Next.js 15 with App Router
+- **Database**: PostgreSQL with Prisma ORM
+- **Authentication**: NextAuth.js with Google OAuth
+- **AI Integration**: Anthropic Claude API
+- **Analytics**: PostHog
+- **Testing**: Vitest with Testing Library
+- **Styling**: Tailwind CSS
+
+### Core Features
+This is a language learning platform called "Write Right" that uses:
+1. **Spaced Repetition System**: Cards with algorithmic scheduling based on user performance
+2. **AI-Generated Content**: Anthropic Claude generates contextual sentences and learning materials
+3. **Multi-language Support**: Supports Danish, English, Spanish, Portuguese, and Italian
+4. **Progressive Learning**: Onboarding flow with native/target language selection
+
+### Key Architecture Patterns
+
+#### Database Schema
+- **User**: Core user model with language preferences and onboarding status
+- **Card**: Spaced repetition cards with easeFactor, interval, and nextDueDate
+- **Sentence**: AI-generated learning content with translations
+- **Word**: Individual word definitions within sentences
+- **CardReviewLog**: Review history for spaced repetition algorithm
+
+#### Spaced Repetition Algorithm
+Located in `src/features/card/logic/`:
+- `processCardReview.ts` - Main entry point for card review processing
+- `calculateEaseFactor.ts` - Adjusts difficulty based on user performance
+- `calculateNextInterval.ts` - Determines next review timing
+- `calculateNextDueDate.ts` - Calculates when card should appear next
+
+#### Feature Organization
+Features are organized in `src/features/` with:
+- `logic/` - Core business logic and algorithms
+- `services/` - API interaction and data fetching
+- `components/` - Feature-specific UI components
+- `types.ts` - Feature-specific TypeScript types
+
+### API Routes Structure
+- `POST /api/sentence` - Generate new practice sentences via AI
+- `GET /api/card/types/sentence/[userId]` - Fetch user's practice cards
+- `POST /api/card/[cardId]/review` - Submit card review with rating (0, 3, or 5)
+- `PUT /api/user/[userId]/language-preference` - Update target learning language
+- `PUT /api/user/[userId]/native-language` - Update native language
+
+### Authentication Flow
+- Uses NextAuth.js with Google OAuth
+- Custom callbacks handle user creation/lookup via profile feature
+- Session includes user ID for database operations
+- Redirect to `/login` for unauthenticated users
+
+### Environment Variables
+Required environment variables (see `.env.example`):
+- `DATABASE_URL` - PostgreSQL connection string
+- `ANTHROPIC_API_KEY` - For AI content generation
+- `AUTH_SECRET` - NextAuth.js secret
+- `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET` - Google OAuth credentials
+- `NEXT_PUBLIC_POSTHOG_KEY` - Analytics (optional)
+
+### Key Directories
+- `src/app/` - Next.js App Router pages and API routes
+- `src/features/` - Feature-specific code organized by domain
+- `src/components/` - Reusable UI components
+- `src/lib/` - Utility libraries and API helpers
+- `src/prompts/` - AI prompt templates for content generation
+- `prisma/` - Database schema and migrations

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,20 +9,21 @@ generator client {
 }
 
 datasource db {
-  provider  = "postgresql"
-  url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model User {
-  id                  String  @id @unique @default(uuid())
-  email               String  @unique
+  id                  String    @id @unique @default(uuid())
+  email               String    @unique
   firstName           String?
   lastName            String?
-  status              String  @default("ACTIVE")
+  status              String    @default("ACTIVE")
   password            String
-  nativeLanguage      String  @default("en")
-  onboardingCompleted Boolean @default(false)
+  nativeLanguage      String    @default("en")
+  onboardingCompleted Boolean   @default(false)
+  currentEloScore     Int       @default(1200)
+  lastSessionTimestamp DateTime?
 
   createdAt     DateTime        @default(now())
   updatedAt     DateTime        @updatedAt
@@ -30,6 +31,7 @@ model User {
   Card          Card[]
   CardReviewLog CardReviewLog[]
   UserSettings  UserSettings[]
+  Session       Session[]
 
   @@map("user")
 }
@@ -42,6 +44,7 @@ model Sentence {
   language       String?
   nativeLanguage String?
   audioUrl       String?
+  difficultyElo  Int     @default(1200)
 
   words Word[]
   Card  Card[]
@@ -81,15 +84,20 @@ model Card {
 }
 
 model CardReviewLog {
-  id         String   @id @unique @default(uuid())
-  reviewDate DateTime @default(now())
-  rating     Int      @default(0) // rating 0, 3 or 5
+  id             String   @id @unique @default(uuid())
+  reviewDate     DateTime @default(now())
+  rating         Int      @default(0) // rating 0, 3 or 5
+  streakPosition Int      @default(0)
+  eloImpact      Float    @default(0.0)
 
   card   Card?   @relation(fields: [cardId], references: [id], onDelete: SetNull)
   cardId String?
 
   userId String?
   user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  session   Session? @relation(fields: [sessionId], references: [id], onDelete: SetNull)
+  sessionId String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -188,4 +196,22 @@ model UserSettings {
   updatedAt DateTime @updatedAt
 
   @@map("user_settings")
+}
+
+model Session {
+  id               String    @id @unique @default(uuid())
+  userId           String
+  startTimestamp   DateTime  @default(now())
+  endTimestamp     DateTime?
+  startingUserElo  Int
+  endingUserElo    Int?
+  status           String    @default("ACTIVE") // ACTIVE or COMPLETED
+
+  user          User            @relation(fields: [userId], references: [id])
+  CardReviewLog CardReviewLog[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("session")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,15 +14,15 @@ datasource db {
 }
 
 model User {
-  id                  String    @id @unique @default(uuid())
-  email               String    @unique
-  firstName           String?
-  lastName            String?
-  status              String    @default("ACTIVE")
-  password            String
-  nativeLanguage      String    @default("en")
-  onboardingCompleted Boolean   @default(false)
-  currentEloScore     Int       @default(1200)
+  id                   String    @id @unique @default(uuid())
+  email                String    @unique
+  firstName            String?
+  lastName             String?
+  status               String    @default("ACTIVE")
+  password             String
+  nativeLanguage       String    @default("en")
+  onboardingCompleted  Boolean   @default(false)
+  currentEloScore      Int       @default(1200)
   lastSessionTimestamp DateTime?
 
   createdAt     DateTime        @default(now())
@@ -199,15 +199,15 @@ model UserSettings {
 }
 
 model Session {
-  id               String    @id @unique @default(uuid())
-  userId           String
-  startTimestamp   DateTime  @default(now())
-  endTimestamp     DateTime?
-  startingUserElo  Int
-  endingUserElo    Int?
-  status           String    @default("ACTIVE") // ACTIVE or COMPLETED
+  id              String    @id @unique @default(uuid())
+  userId          String?
+  startTimestamp  DateTime  @default(now())
+  endTimestamp    DateTime?
+  startingUserElo Int
+  endingUserElo   Int?
+  status          String    @default("ACTIVE") // ACTIVE or COMPLETED
 
-  user          User            @relation(fields: [userId], references: [id])
+  user          User?           @relation(fields: [userId], references: [id], onDelete: SetNull)
   CardReviewLog CardReviewLog[]
 
   createdAt DateTime @default(now())

--- a/src/features/card/logic/__tests__/processCardReview.test.ts
+++ b/src/features/card/logic/__tests__/processCardReview.test.ts
@@ -28,10 +28,15 @@ describe("processCardReview", () => {
     vi.spyOn(dueDate, "calculateNextDueDate").mockReturnValue(
       new Date("2023-01-27T00:00:00Z")
     );
+    
+    // Mock Date constructor to return consistent time
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(mockCurrentTime));
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   it("should process a successful review (rating >= 3)", () => {
@@ -60,7 +65,7 @@ describe("processCardReview", () => {
       interval: 12,
       newDueDate: new Date("2023-01-27T00:00:00Z"),
       repetitions: 3, // Incremented
-      lastReviewedAt: mockCurrentTime,
+      lastReviewedAt: new Date(mockCurrentTime),
     });
   });
 
@@ -90,7 +95,7 @@ describe("processCardReview", () => {
       interval: 12,
       newDueDate: new Date("2023-01-27T00:00:00Z"),
       repetitions: 0, // Reset to 0 on failure
-      lastReviewedAt: mockCurrentTime,
+      lastReviewedAt: new Date(mockCurrentTime),
     });
   });
 


### PR DESCRIPTION
Implementation of basic data structures for holding the session and progress information necessary for keeping track of the ELO scores.

This pull request introduces several key changes, including the addition of a comprehensive development guide, updates to the Prisma schema for new features, and improvements to test consistency. Below is a summary of the most important changes:

### Database Schema Updates:
* Removed the `directUrl` field from the `datasource db` block in `prisma/schema.prisma`.
* Updated the `User` model to include `currentEloScore` (with a default of 1200) and `lastSessionTimestamp`. Added a relationship to the new `Session` model.
* Added a `difficultyElo` field (default 1200) to the `Sentence` model to track sentence difficulty.
* Enhanced the `CardReviewLog` model with `streakPosition`, `eloImpact`, and a relationship to the `Session` model.
* Introduced a new `Session` model to track user sessions, including ELO changes and session status.